### PR TITLE
Throw 401 for security denial for unauthenticated

### DIFF
--- a/src/pyramid/viewderivers.py
+++ b/src/pyramid/viewderivers.py
@@ -2,7 +2,7 @@ import inspect
 
 from zope.interface import implementer, provider
 
-from pyramid.security import NO_PERMISSION_REQUIRED
+from pyramid.security import NO_PERMISSION_REQUIRED, Authenticated
 from pyramid.csrf import check_csrf_origin, check_csrf_token
 from pyramid.response import Response
 
@@ -20,7 +20,7 @@ from pyramid.interfaces import (
 from pyramid.compat import is_bound_method, is_unbound_method
 
 from pyramid.exceptions import ConfigurationError
-from pyramid.httpexceptions import HTTPForbidden
+from pyramid.httpexceptions import HTTPForbidden, HTTPUnauthorized
 from pyramid.util import object_description, takes_one_arg
 from pyramid.view import render_view_to_response
 from pyramid import renderers
@@ -329,7 +329,9 @@ def _secured_view(view, info):
                 'authdebug_message',
                 'Unauthorized: %s failed permission check' % view_name,
             )
-            raise HTTPForbidden(msg, result=result)
+            if Authenticated in result.principals:
+                raise HTTPForbidden(msg, result=result)
+            raise HTTPUnauthorized(msg)
 
         wrapped_view = secured_view
         wrapped_view.__call_permissive__ = view


### PR DESCRIPTION
The security framework currently throws HTTPForbidden for security failures, regardless of user context. 

To better align with security frameworks, such as repoze.who, and internet convention, pyramid should throw 401 for unauthenticated users, to give them the opportunity to log in and try again....